### PR TITLE
Add timeout to search entry focus

### DIFF
--- a/mate_menu/plugins/applications.py
+++ b/mate_menu/plugins/applications.py
@@ -715,7 +715,7 @@ class pluginclass( object ):
                         self.applicationsBox.add(i)
                         if not focused:
                             # Grab focus of the first app shown
-                            i.grab_focus()
+                            GLib.timeout_add(20, i.grab_focus)
                             focused = True
                     if self.alwaysshowsearch:
                         self.add_search_suggestions(text, focused)


### PR DESCRIPTION
This fixes an issue where the pointer steals focus of another
application within the same application list whenever the user is
typing. The timeout ensures that the first element is selected
regardless of the position of the pointer.

At this point, it seems more like a hack than anything, but it seems to
fix the behavior. I'm starting to think a refactoring is due...