### PR TITLE
Use gtk-missing-image to replace application-default-icon image

### DIFF
--- a/mate_menu/easybuttons.py
+++ b/mate_menu/easybuttons.py
@@ -233,7 +233,7 @@ class easyButton( Gtk.Button ):
 
         icon = iconManager.getIcon( self.iconName, iconSize )
         if icon is None:
-            icon = iconManager.getIcon( "application-default-icon", iconSize )
+            icon = iconManager.getIcon( "gtk-missing-image", iconSize )
 
         return icon
 


### PR DESCRIPTION
mate-icon-theme 1.20.0-1 include gtk-missing-image.png, but no application-default-icon image, so if applications/directory's icon lost, I can't see any image before it, so use gtk-missing-image will be better.