### PR TITLE
add darker MATE logo

### DIFF
--- a/data/icons/mate-logo-dark.svg
+++ b/data/icons/mate-logo-dark.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   height="16"
+   width="16"
+   version="1.0"
+   sodipodi:docname="mate-logo-dark.svg"
+   inkscape:version="0.92.4 (unknown)">
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1805"
+     inkscape:window-height="1325"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="59"
+     inkscape:cx="2.7542373"
+     inkscape:cy="8"
+     inkscape:window-x="456"
+     inkscape:window-y="592"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer2"
+     display="none"
+     transform="translate(0,-6)">
+    <rect
+       id="rect4898"
+       fill-rule="nonzero"
+       height="22"
+       width="22"
+       y="0"
+       x="0"
+       fill="#333" />
+  </g>
+  <g
+     id="layer3"
+     display="none"
+     transform="translate(0,-6)">
+    <rect
+       id="rect4126"
+       fill-rule="nonzero"
+       height="22"
+       width="22"
+       y="0"
+       x="0"
+       fill="#efebe7" />
+  </g>
+  <g
+     id="layer1"
+     transform="matrix(1.0319689,0,0,1.0563566,-0.69397664,-6.778957)"
+     stroke-miterlimit="4"
+     stroke-width="0"
+     fill="#bebebe"
+     style="fill:#474747;fill-opacity:1">
+    <path
+       id="path5070"
+       fill-rule="evenodd"
+       d="m1.6415,10.204,6.7832,3.7866-6.7832,3.7866z"
+       style="fill:#474747;fill-opacity:1" />
+    <path
+       id="path5067"
+       d="m15.208,13.991c0-3.658-3.131-6.6271-6.7834-6.6271-2.109,0-4.1361,1.0094-5.348,2.5503l0.85177,0.47616c1.034-1.2658,2.7359-2.0798,4.4963-2.0798,3.1115-1E-7,5.8141,2.5683,5.8141,5.6799,0,3.1115-2.7025,5.6799-5.8141,5.6799-1.7553,0-3.5475-0.92376-4.5815-2.183l-0.84886,0.47427c1.2122,1.5345,3.3264,2.6554,5.4304,2.6554,3.6524,0,6.7832-2.9686,6.7832-6.6266z"
+       style="fill:#474747;fill-opacity:1" />
+    <path
+       id="path5648"
+       d="m12.301,13.99c0-2.2361-1.64-3.7866-3.8761-3.7866-1.1905,0-2.0368,0.32699-2.7782,1.1454l0.8789,0.49036c0.55229-0.54547,1.065-0.68916,1.8993-0.68916,1.6896,0,2.9071,1.1392,2.9071,2.84s-1.2175,2.84-2.9071,2.84c-0.84982,0-1.4491-0.21841-2.0039-0.78193l-0.86824,0.48468c0.74137,0.81851,1.6817,1.2439,2.8722,1.2439,2.2361,0,3.8761-1.5505,3.8761-3.7866z"
+       style="fill:#474747;fill-opacity:1" />
+  </g>
+</svg>

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ data_files = [
     ("share/mate-menu/icons".format(prefix=sys.prefix),
         [
             "data/icons/mate-logo.svg",
+            "data/icons/mate-logo-dark.svg",
             "data/icons/dictionary.png",
         ]
     ),


### PR DESCRIPTION
fixes https://github.com/ubuntu-mate/mate-menu/issues/46

This darker logo can be chosen if a light panel is used.

But i think HIDPI scaling needs to be added for this icon.

I hope the new logo will be installed. Python isn't really my business :)