### PR TITLE
Remove search focus delay

### DIFF
--- a/mate_menu/easybuttons.py
+++ b/mate_menu/easybuttons.py
@@ -173,6 +173,8 @@ class easyButton( Gtk.Button ):
         HBox1.show()
         self.add( HBox1 )
 
+        self.set_events(Gdk.EventMask.POINTER_MOTION_MASK)
+        self.connectSelf( "motion-notify-event", self.onMotion )
         self.connectSelf( "enter-notify-event", self.onEnter )
         self.connectSelf( "focus-in-event", self.onFocusIn )
         self.connectSelf( "focus-out-event", self.onFocusOut )
@@ -184,8 +186,16 @@ class easyButton( Gtk.Button ):
     def connectSelf( self, event, callback ):
         self.connections.append( self.connect( event, callback ) )
 
+    def onMotion( self, widget, event ):
+        # Only grab if mouse is actually hovering
+        if self.mouse_entered:
+            self.grab_focus()
+            self.mouse_entered = False
+
     def onEnter( self, widget, event ):
-        self.grab_focus()
+        # Prevent false "enter" notifications by determining
+        # whether the mouse is actually hovering on the button.
+        self.mouse_entered = True
 
     def onFocusIn( self, widget, event ):
         self.set_state_flags( Gtk.StateFlags.PRELIGHT, False )

--- a/mate_menu/plugins/applications.py
+++ b/mate_menu/plugins/applications.py
@@ -572,20 +572,14 @@ class pluginclass( object ):
         widget.unset_state_flags( Gtk.StateFlags.PRELIGHT )
 
     def focusSearchEntry( self, clear = True ):
-        def doFocusSearchEntry():
-            # grab_focus() does select all text,
-            # restoring the original selection is somehow broken, so just select the end
-            # of the existing text, that's the most likely candidate anyhow
-            self.searchEntry.grab_focus()
-            if self.rememberFilter or not clear:
-                self.searchEntry.set_position(-1)
-            else:
-                self.searchEntry.set_text("")
-
-        # Focus after a small timeout so that the pointer doesn't steal focus
-        # from the search entry if its position happens to be within the menu
-        # window.
-        GLib.timeout_add(100, doFocusSearchEntry)
+        # grab_focus() does select all text,
+        # restoring the original selection is somehow broken, so just select the end
+        # of the existing text, that's the most likely candidate anyhow
+        self.searchEntry.grab_focus()
+        if self.rememberFilter or not clear:
+            self.searchEntry.set_position(-1)
+        else:
+            self.searchEntry.set_text("")
 
     def buildButtonList( self ):
         if self.buildingButtonList:

--- a/mate_menu/plugins/recent.py
+++ b/mate_menu/plugins/recent.py
@@ -76,6 +76,7 @@ class pluginclass:
         #Connect event handlers
         clr_btn = self.builder.get_object("ClrBtn")
         clr_btn.connect("clicked", self.clrmenu)
+        clr_btn.connect("motion-notify-event", self.onMotion)
         clr_btn.connect("enter-notify-event", self.onEnter)
         clr_btn.connect("focus-in-event", self.onFocusIn)
         clr_btn.connect("focus-out-event", self.onFocusOut)
@@ -154,6 +155,8 @@ class pluginclass:
         AButton.remove( AButton.get_children()[0] )
         AButton.set_size_request( 200, -1 )
         AButton.set_relief( Gtk.ReliefStyle.NONE )
+        AButton.set_events( Gdk.EventMask.POINTER_MOTION_MASK )
+        AButton.connect( "motion-notify-event", self.onMotion )
         AButton.connect( "enter-notify-event", self.onEnter )
         AButton.connect( "focus-in-event", self.onFocusIn )
         AButton.connect( "focus-out-event", self.onFocusOut )
@@ -176,8 +179,16 @@ class pluginclass:
 
         self.recentBox.pack_start( AButton, False, True, 0 )
 
+    def onMotion(self, widget, event):
+        # Only grab if mouse is actually hovering
+        if self.mouse_entered:
+            widget.grab_focus()
+            self.mouse_entered = False
+
     def onEnter(self, widget, event):
-        widget.grab_focus()
+        # Prevent false "enter" notifications by determining
+        # whether the mouse is actually hovering on the button.
+        self.mouse_entered = True
 
     def onFocusIn(self, widget, event):
         widget.set_state_flags( Gtk.StateFlags.PRELIGHT, False )


### PR DESCRIPTION
When opening the menu, the search text input gets focused after a 100ms
delay. This was done to avoid the mouse stealing focus when the pointer
was in the way of the menu prior to opening. However, it meant that if
the user starts typing immediately after opening the menu, your search
input focus would be lost.

This is now solved by only allowing the pointer to focus on buttons
after it has actually moved over them after entering. Now the user
should be able to start typing their application name immediately,
making the whole search menu experience more responsive.