### PR TITLE
Set window title

### DIFF
--- a/lib/mate-menu.py
+++ b/lib/mate-menu.py
@@ -84,7 +84,7 @@ class MainWindow( object ):
 
         self.window.realize()
         self.window.get_window().set_decorations(Gdk.WMDecoration.BORDER)
-        self.window.set_title('')
+        self.window.set_title('Advanced MATE Menu')
         self.window.set_app_paintable(True)
 
         self.window.connect("draw", self.onWindowDraw)


### PR DESCRIPTION
This fixes issues in which a global menu tries to display information
about the toplevel focused window when the mate-menu is open.

Fixes #69 