### PR TITLE
Use GAppInfo to launch applications

### DIFF
--- a/mate_menu/plugins/applications.py
+++ b/mate_menu/plugins/applications.py
@@ -32,7 +32,6 @@ import shlex
 import subprocess
 import filecmp
 from mate_menu.easybuttons import *
-from mate_menu.execute import Execute
 from mate_menu.easygsettings import EasyGSettings
 from mate_menu.easyfiles import *
 


### PR DESCRIPTION
This removes the need to rely on hacks like double-fork. It also fixes
an issue where certain windows launched through mate-menu are not
immediately in focus.