### PR TITLE
Fix opening Desktop entries with Path

### DIFF
--- a/mate_menu/execute.py
+++ b/mate_menu/execute.py
@@ -36,7 +36,7 @@ def RemoveArgs(Execline):
 # Actually launch the application
 def Launch(cmd, cwd=None):
 	if cwd:
-		cmd = cwd + ' ' + cmd
+		os.chdir(cwd)
 
 	app_info = Gio.AppInfo.create_from_commandline(cmd,
 						       None,


### PR DESCRIPTION
Desktop Entry files can specify a working directory for the path.
Instead of prepending that path to the command, we instead change the
current working directory in the executable context so that those
applications can load correctly.

Fixes https://github.com/ubuntu-mate/mate-menu/issues/75