### PR TITLE
applications: Allow disabling category hover

### DIFF
--- a/mate_menu/plugins/applications.py
+++ b/mate_menu/plugins/applications.py
@@ -1454,11 +1454,11 @@ class pluginclass( object ):
                             startId = item["button"].connect( "enter", self.StartFilter, item["filter"] )
                             stopId = item["button"].connect( "leave", self.StopFilter )
                             item["button"].mouseOverHandlerIds = ( startId, stopId )
+                            item["button"].connect( "focus-in-event", self.categoryBtnFocus, item["filter"] )
                         else:
                             item["button"].mouseOverHandlerIds = None
 
                         item["button"].connect( "clicked", self.FilterAndClear, item["filter"] )
-                        item["button"].connect( "focus-in-event", self.categoryBtnFocus, item["filter"] )
                         item["button"].show()
 
                         self.categoryList.append( item )


### PR DESCRIPTION
When disabling the categories hover option, the code ignores the setting
and continues filtering on focus. Moving the focus event handler inside
the option conditional fixes the behaviour.