### PR TITLE
Fix categories without icon

### DIFF
--- a/mate_menu/plugins/applications.py
+++ b/mate_menu/plugins/applications.py
@@ -1569,7 +1569,11 @@ class pluginclass( object ):
             for child in get_contents(menu.directory):
                 if isinstance(child, MateMenu.TreeDirectory):
                     name = child.get_name()
-                    icon = child.get_icon().to_string()
+                    icon = child.get_icon()
+                    if ( icon == None ):
+                        icon = "applications-other"
+                    else:
+                        icon = icon.to_string()
                     newCategoryList.append( { "name": name, "icon": icon, "tooltip": name, "filter": name, "index": num } )
             num += 1
 


### PR DESCRIPTION
For example, Citrix StoreFront sub-system generate menu file without <Directory> tag. Application plugin get from get_icon() value None and try to call .to_string(). Because it generates exception therefore any other categories did not process and menu is empty. This commit catches this situation and substitutes 'application-other' icon for categories without icon.