### PR TITLE
Add CSS classes

### DIFF
--- a/data/plugins/applications.glade
+++ b/data/plugins/applications.glade
@@ -154,6 +154,9 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="homogeneous">True</property>
+                        <style>
+                            <class name="mint-title"/>
+                        </style>
                         <child>
                           <object class="GtkLabel" id="label2">
                             <property name="visible">True</property>
@@ -238,6 +241,9 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="hscrollbar_policy">never</property>
+                            <style>
+                                <class name="mint-categories-list"/>
+                            </style>
                             <child>
                               <object class="GtkViewport" id="viewport1">
                                 <property name="visible">True</property>
@@ -281,6 +287,9 @@
                             <property name="can_focus">False</property>
                             <property name="can_default">True</property>
                             <property name="hscrollbar_policy">never</property>
+                            <style>
+                                <class name="mint-applications-list"/>
+                            </style>
                             <child>
                               <object class="GtkViewport" id="viewport3">
                                 <property name="visible">True</property>
@@ -332,6 +341,9 @@
                 <property name="height_request">30</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <style>
+                    <class name="mint-search"/>
+                </style>
                 <child>
                   <object class="GtkLabel" id="searchLabel">
                     <property name="visible">True</property>

--- a/lib/mate-menu.py
+++ b/lib/mate-menu.py
@@ -216,6 +216,7 @@ class MainWindow( object ):
                 MyPlugin.content_holder.show()
 
                 VBox1 = Gtk.Box( orientation=Gtk.Orientation.VERTICAL )
+                VBox1.get_style_context().add_class( "mint-" + plugin.replace( "_", "-" ) )
                 if MyPlugin.heading != "":
                     Label1 = Gtk.Label(label= MyPlugin.heading )
                     Label1.set_margin_start(10)
@@ -232,6 +233,7 @@ class MainWindow( object ):
                         Label1.set_margin_bottom(5)
                         heading.set_size_request( MyPlugin.width, -1 )
 
+                    heading.get_style_context().add_class( "mint-title" )
                     heading.add(Label1)
                     heading.show()
                     VBox1.pack_start( heading, False, False, 0 )

--- a/lib/mate-menu.py
+++ b/lib/mate-menu.py
@@ -563,6 +563,7 @@ class MenuWin( object ):
             self.button_icon.set_margin_top(5)
             self.button_icon.set_margin_bottom(5)
 
+        self.button_box.get_style_context().add_class( "mate-menu" )
         self.button_box.set_homogeneous( False )
         self.button_box.show_all()
 


### PR DESCRIPTION
Original PR is https://github.com/linuxmint/mintmenu/pull/285.

![image](https://github.com/user-attachments/assets/92b49625-9efe-4687-9def-c12f5a3a96d8)

(replace `#mintmenu` with `#mate-menu` / maybe I can replace also new `mint` CSS classes with `mate`?)