### PR TITLE
Clean up .glade UI files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 dist
 *.egg-info
 *.pyc
+*.glade~

--- a/data/mate-menu-config.glade
+++ b/data/mate-menu-config.glade
@@ -281,7 +281,7 @@
     </child>
     <action-widgets>
       <action-widget response="-5">button1</action-widget>
-      <action-widget response="0">button2</action-widget>
+      <action-widget response="-6">button2</action-widget>
     </action-widgets>
   </object>
   <object class="GtkListStore" id="model1">
@@ -297,7 +297,6 @@
   </object>
   <object class="GtkWindow" id="mainWindow">
     <property name="can_focus">False</property>
-    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="border_width">6</property>
     <property name="window_position">center</property>
     <property name="destroy_with_parent">True</property>
@@ -308,13 +307,11 @@
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkNotebook" id="notebook1">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="border_width">4</property>
             <child>
               <object class="GtkFrame" id="frame1">
@@ -341,7 +338,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="draw_indicator">True</property>
                       </object>
@@ -355,7 +351,6 @@
                       <object class="GtkLabel" id="buttonTextLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Button text:</property>
                       </object>
@@ -368,7 +363,6 @@
                       <object class="GtkEntry" id="buttonText">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="invisible_char">●</property>
                         <property name="primary_icon_activatable">False</property>
                         <property name="secondary_icon_activatable">False</property>
@@ -398,7 +392,6 @@
               <object class="GtkLabel" id="mainbuttonLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Main button</property>
               </object>
               <packing>
@@ -462,7 +455,6 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="draw_indicator">True</property>
                           </object>
                           <packing>
@@ -477,7 +469,6 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="draw_indicator">True</property>
                           </object>
                           <packing>
@@ -492,7 +483,6 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="draw_indicator">True</property>
                           </object>
                           <packing>
@@ -523,7 +513,6 @@
                               <object class="GtkSpinButton" id="borderWidth">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="invisible_char">●</property>
                                 <property name="primary_icon_activatable">False</property>
                                 <property name="secondary_icon_activatable">False</property>
@@ -573,7 +562,6 @@
               <object class="GtkLabel" id="pluginsLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Plugins</property>
               </object>
               <packing>
@@ -585,7 +573,6 @@
               <object class="GtkFrame" id="frame8">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="margin_left">10</property>
                 <property name="margin_right">10</property>
                 <property name="margin_top">10</property>
@@ -603,7 +590,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="margin_top">10</property>
                         <property name="draw_indicator">True</property>
                       </object>
@@ -619,7 +605,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -634,7 +619,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -647,9 +631,8 @@
                       <object class="GtkLabel" id="hoverLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Hover delay (seconds):</property>
+                        <property name="label" translatable="yes">Hover delay (ms):</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -660,9 +643,8 @@
                       <object class="GtkSpinButton" id="hoverDelay">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="invisible_char">●</property>
-                        <property name="text" translatable="yes">100</property>
+                        <property name="text">100</property>
                         <property name="primary_icon_activatable">False</property>
                         <property name="secondary_icon_activatable">False</property>
                         <property name="adjustment">adjustment4</property>
@@ -677,7 +659,6 @@
                       <object class="GtkLabel" id="iconSizeLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Icon size:</property>
                       </object>
@@ -690,9 +671,8 @@
                       <object class="GtkSpinButton" id="iconSize">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="invisible_char">●</property>
-                        <property name="text" translatable="yes">1</property>
+                        <property name="text">1</property>
                         <property name="primary_icon_activatable">False</property>
                         <property name="secondary_icon_activatable">False</property>
                         <property name="adjustment">adjustment3</property>
@@ -707,7 +687,6 @@
                       <object class="GtkLabel" id="label5">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Search command:</property>
                       </object>
@@ -720,7 +699,6 @@
                       <object class="GtkEntry" id="search_command">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_STRUCTURE_MASK</property>
                         <property name="invisible_char">●</property>
                         <property name="primary_icon_activatable">False</property>
                         <property name="secondary_icon_activatable">False</property>
@@ -736,7 +714,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -751,7 +728,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -766,7 +742,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -780,7 +755,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -794,7 +768,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -808,7 +781,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -822,7 +794,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -834,7 +805,6 @@
                       <object class="GtkLabel" id="searchEngineTitleLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="label" translatable="yes">Search Engines:</property>
                       </object>
                       <packing>
@@ -883,7 +853,6 @@
               <object class="GtkLabel" id="applicationsLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Applications</property>
               </object>
               <packing>
@@ -895,7 +864,6 @@
               <object class="GtkFrame" id="frame9">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="margin_left">10</property>
                 <property name="margin_right">10</property>
                 <property name="margin_top">10</property>
@@ -913,7 +881,6 @@
                       <object class="GtkLabel" id="numberColumnsLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Number of columns:</property>
                       </object>
@@ -926,8 +893,7 @@
                       <object class="GtkSpinButton" id="numFavCols">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="text" translatable="yes">1</property>
+                        <property name="text">1</property>
                         <property name="primary_icon_activatable">False</property>
                         <property name="secondary_icon_activatable">False</property>
                         <property name="adjustment">adjustment5</property>
@@ -942,7 +908,6 @@
                       <object class="GtkLabel" id="iconSizeLabel2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Icon size:</property>
                       </object>
@@ -955,8 +920,7 @@
                       <object class="GtkSpinButton" id="favIconSize">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="text" translatable="yes">1</property>
+                        <property name="text">1</property>
                         <property name="primary_icon_activatable">False</property>
                         <property name="secondary_icon_activatable">False</property>
                         <property name="adjustment">adjustment6</property>
@@ -973,7 +937,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -993,7 +956,6 @@
               <object class="GtkLabel" id="favLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Favorites</property>
               </object>
               <packing>
@@ -1086,7 +1048,6 @@
                           <object class="GtkLabel" id="placesIconSizeLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Icon size:</property>
                           </object>
@@ -1100,7 +1061,6 @@
                           <object class="GtkSpinButton" id="placesIconSize">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="invisible_char">●</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
@@ -1510,7 +1470,6 @@
                           <object class="GtkLabel" id="systemIconSizeLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Icon size:</property>
                           </object>
@@ -1524,7 +1483,6 @@
                           <object class="GtkSpinButton" id="systemIconSize">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="invisible_char">●</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
@@ -1687,7 +1645,6 @@
           <object class="GtkButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="border_width">3</property>
             <property name="layout_style">spread</property>
             <child>
@@ -1696,7 +1653,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>

--- a/data/plugins/applications.glade
+++ b/data/plugins/applications.glade
@@ -27,7 +27,6 @@
                   <object class="GtkBox" id="vbox5">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="border_width">3</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">3</property>
@@ -41,7 +40,8 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="xpad">15</property>
-                            <property name="ypad">10</property>
+                            <property name="margin_top">7</property>
+                            <property name="margin_bottom">5</property>
                             <property name="label" translatable="yes">&lt;span weight="bold"&gt;Favorites&lt;/span&gt;</property>
                             <property name="use_markup">True</property>
                             <property name="xalign">0</property>
@@ -115,7 +115,6 @@
                       <object class="GtkViewport" id="viewport2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="resize_mode">queue</property>
                         <property name="shadow_type">none</property>
                         <child>
@@ -159,7 +158,8 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="xpad">15</property>
-                            <property name="ypad">10</property>
+                            <property name="margin_top">7</property>
+                            <property name="margin_bottom">5</property>
                             <property name="label" translatable="yes">&lt;span weight="bold"&gt;All Applications&lt;/span&gt;</property>
                             <property name="use_markup">True</property>
                             <property name="xalign">0</property>
@@ -265,7 +265,6 @@
                           <object class="GtkSeparator" id="vseparator1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="orientation">vertical</property>
                           </object>
                           <packing>
@@ -278,8 +277,7 @@
                         <child>
                           <object class="GtkScrolledWindow" id="applicationsScrolledWindow">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="can_default">True</property>
+                            <property name="can_focus">True</property>
                             <property name="hscrollbar_policy">never</property>
                             <child>
                               <object class="GtkViewport" id="viewport3">
@@ -351,13 +349,9 @@
                     <property name="height_request">25</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="has_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="has_default">True</property>
                     <property name="activates_default">True</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="secondary_icon_activatable">False</property>
-                    <signal name="changed" handler="on_entry1_changed" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -371,17 +365,11 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="focus_on_click">False</property>
-                    <property name="can_default">True</property>
-                    <property name="has_default">True</property>
                     <property name="receives_default">False</property>
                     <property name="relief">none</property>
-                    <signal name="clicked" handler="on_button17_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="image1">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="can_default">True</property>
-                        <property name="has_default">True</property>
                         <property name="stock">gtk-find</property>
                         <property name="icon_size">1</property>
                       </object>

--- a/data/plugins/places.glade
+++ b/data/plugins/places.glade
@@ -4,7 +4,6 @@
   <object class="GtkWindow" id="mainWindow">
     <property name="can_focus">False</property>
     <property name="border_width">3</property>
-    <signal name="destroy" handler="on_window1_destroy" swapped="no"/>
     <child>
       <object class="GtkEventBox" id="Places">
         <property name="visible">True</property>
@@ -14,9 +13,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="border_width">3</property>
-            <signal name="drag-data-received" handler="on_scrolledwindow_drag_data_received" swapped="no"/>
-            <signal name="drag-drop" handler="on_scrolledwindow_drag_drop" swapped="no"/>
-            <signal name="drag-motion" handler="on_scrolledwindow_drag_motion" swapped="no"/>
             <child>
               <object class="GtkViewport" id="viewport2">
                 <property name="visible">True</property>
@@ -31,7 +27,6 @@
                       <object class="GtkBox" id="places_button_holder">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">2</property>
                       </object>

--- a/data/plugins/recent.glade
+++ b/data/plugins/recent.glade
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.0"/>
-  <object class="GtkWindow" id="window1">
+  <object class="GtkWindow" id="mainWindow">
     <property name="can_focus">False</property>
     <property name="border_width">3</property>
-    <property name="title" translatable="yes">window1</property>
     <child>
-      <object class="GtkEventBox" id="eventbox1">
+      <object class="GtkEventBox" id="Recent">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">5</property>
         <child>
           <object class="GtkBox" id="vbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="border_width">3</property>
             <property name="orientation">vertical</property>
             <property name="spacing">3</property>
             <child>
@@ -21,6 +20,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="show_tabs">False</property>
+                <property name="show_border">False</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
@@ -29,6 +29,7 @@
                       <object class="GtkViewport" id="viewport2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkButtonBox" id="RecentApps">
                             <property name="visible">True</property>
@@ -57,7 +58,7 @@
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
                     <child>
                       <object class="GtkViewport" id="viewport1">
                         <property name="visible">True</property>
@@ -104,7 +105,6 @@
                 <property name="receives_default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_ClrBtn_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/data/plugins/system_management.glade
+++ b/data/plugins/system_management.glade
@@ -4,7 +4,6 @@
   <object class="GtkWindow" id="mainWindow">
     <property name="can_focus">False</property>
     <property name="border_width">3</property>
-    <signal name="destroy" handler="on_window1_destroy" swapped="no"/>
     <child>
       <object class="GtkEventBox" id="System">
         <property name="visible">True</property>
@@ -14,9 +13,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="border_width">3</property>
-            <signal name="drag-data-received" handler="on_scrolledwindow_drag_data_received" swapped="no"/>
-            <signal name="drag-drop" handler="on_scrolledwindow_drag_drop" swapped="no"/>
-            <signal name="drag-motion" handler="on_scrolledwindow_drag_motion" swapped="no"/>
             <child>
               <object class="GtkViewport" id="viewport2">
                 <property name="visible">True</property>
@@ -31,7 +27,6 @@
                       <object class="GtkBox" id="system_button_holder">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">2</property>
                       </object>

--- a/lib/mate-menu-config.py
+++ b/lib/mate-menu-config.py
@@ -70,7 +70,6 @@ class mateMenuConfig( object ):
         self.builder.get_object("label25").set_text(_("pixels"))
 
         self.builder.get_object("buttonTextLabel").set_text(_("Button text:"))
-        self.builder.get_object("label1").set_text(_("Options"))
         self.builder.get_object("applicationsLabel").set_text(_("Applications"))
 
         self.builder.get_object("favLabel").set_text(_("Favorites"))

--- a/mate_menu/plugins/recent.py
+++ b/mate_menu/plugins/recent.py
@@ -24,7 +24,6 @@ gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk, Pango
 from mate_menu.easygsettings import EasyGSettings
-from mate_menu.execute import Execute
 from mate_menu.easyfiles import *
 from mate_menu.easybuttons import *
 
@@ -42,13 +41,13 @@ class pluginclass:
         self.builder.add_from_file (os.path.join( '/', 'usr', 'share', 'mate-menu',  'plugins', 'recent.glade' ))
 
         #Set 'window' property for the plugin (Must be the root widget)
-        self.window = self.builder.get_object( "window1" )
+        self.window = self.builder.get_object( "mainWindow" )
 
         #Set 'heading' property for plugin
         self.heading = _("Recent documents")
 
         #This should be the first item added to the window in glade
-        self.content_holder = self.builder.get_object( "eventbox1" )
+        self.content_holder = self.builder.get_object( "Recent" )
 
         self.recentBox = self.builder.get_object("RecentBox")
         self.recentVBox = self.builder.get_object( "vbox1" )
@@ -232,24 +231,6 @@ class pluginclass:
                 break
         return FileString,  IconString
 
-
-    def ButtonClicked( self, widget, event, Exec ):
-        self.press_x = event.x
-        self.press_y = event.y
-        self.Exec = Exec
-
-    def ButtonReleased( self, w, ev, ev2 ):
-        if ev.button == 1:
-            if not hasattr( self, "press_x" ) or \
-                    not w.drag_check_threshold( int( self.press_x ),
-                                                                             int( self.press_y ),
-                                                                             int( ev.x ),
-                                                                             int( ev.y ) ):
-                if self.Win.pinmenu == False:
-                    self.Win.wTree.get_widget( "window1" ).hide()
-                if "applications" in self.Win.plugins:
-                    self.Win.plugins["applications"].wTree.get_widget( "entry1" ).grab_focus()
-                Execute( w, self.Exec )
 
     def do_plugin(self):
         self.DoRecent()


### PR DESCRIPTION
This cleans up the .glade UI files that still reference GTK2 stuff. There are no functional changes, but components in the menu are now better aligned.